### PR TITLE
patched over fatal error when the releaseDate was blank

### DIFF
--- a/tidalapi4mopidy/__init__.py
+++ b/tidalapi4mopidy/__init__.py
@@ -235,6 +235,8 @@ def _parse_album(json_obj, artist=None):
             kwargs['release_date'] = datetime.datetime(*map(int, json_obj['releaseDate'].split('-')))
         except ValueError:
             pass
+        except AttributeError:
+            pass
     return Album(**kwargs)
 
 


### PR DESCRIPTION
- added naive error handling for when the releaseDate was blank and split failed, causing a fatal error. 